### PR TITLE
トップページ作成

### DIFF
--- a/components/MoodSelector.vue
+++ b/components/MoodSelector.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="mood-selector">
+    <h2 class="title">今日の元気度合いは？</h2>
+    <p class="subtitle">あなたの気分に合わせたレシピを提案します</p>
+    <div v-if="emoji" class="emoji">{{ emoji }}</div>
+    
+    <div class="mood-buttons">
+      <button
+        v-for="mood in moods"
+        :key="mood.id"
+        @click="selectMood(mood.label)"
+        class="mood-button"
+        :class="{ selected: selectedMood === mood.label }"
+      >
+        {{ mood.label }}
+      </button>
+    </div>
+
+    <button class="confirm-button" @click="comfirmMood">決定</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const moods = ref([
+  { id: 1, label: '元気' },
+  { id: 2, label: 'まあまあ元気' },
+  { id: 3, label: '普通' },
+  { id: 4, label: 'まあまあ疲れた' },
+  { id: 5, label: '疲れた' }
+])
+
+const selectedMood = ref<string | null>(null)
+const emoji = ref<string | null>(null)
+
+const getEmojiForMood = (mood: string): string => {
+  switch (mood) {
+    case '元気':
+      return '💪😆'
+    case 'まあまあ元気':
+      return '😊'
+    case '普通':
+      return '😐'
+    case 'まあまあ疲れた':
+      return '😓'
+    case '疲れた':
+      return '🥱'
+    default:
+      return ''
+  }
+}
+
+const selectMood = (mood: string) => {
+  selectedMood.value = mood
+  emoji.value = getEmojiForMood(mood)
+}
+
+const comfirmMood = () => {
+  // ここでレシピ提案処理などを追加
+}
+</script>
+
+<style scoped>
+.mood-selector {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  padding: 2rem 1rem;
+  max-width: 400px;
+  margin: auto;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  margin-bottom: 1.5rem;
+  color: #555;
+}
+
+.emoji {
+  font-size: 3rem;
+  margin-bottom: 1.5rem;
+  transition: all 0.3s ease;
+}
+
+.mood-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.mood-button {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid #f0a04b;
+  background-color: white;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.2s ease;
+}
+
+.mood-button.selected {
+  background-color: #ffe0b2;
+  font-weight: bold;
+}
+
+.confirm-button {
+  padding: 0.75rem 2rem;
+  background-color: #7be36d;
+  color: #000;
+  font-weight: bold;
+  font-size: 1.1rem;
+  border: none;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.confirm-button:hover {
+  background-color: #6dd25d;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,10 @@
 <template>
-  <div>Hello from Top Page!</div>
+  <div>
+    <MoodSelector />
+  </div>
 </template>
 
-<script setup lang='ts'>
+<script setup lang="ts">
+import MoodSelector from '../components/MoodSelector.vue'
+
 </script>

--- a/shims-vue.d.ts
+++ b/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,16 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.d.ts",
+    "**/*.tsx",
+    "**/*.vue"
+  ]
 }

--- a/vetur.config.js
+++ b/vetur.config.js
@@ -1,0 +1,39 @@
+/** @type {import('vls').VeturConfig} */
+module.exports = {
+  // **optional** default: `{}`
+  // override vscode settings
+  // Notice: It only affects the settings used by Vetur.
+  settings: {
+    "vetur.useWorkspaceDependencies": true,
+    "vetur.experimental.templateInterpolationService": true
+  },
+  // **optional** default: `[{ root: './' }]`
+  // support monorepos
+  projects: [
+    {
+      // **required**
+      // Where is your project?
+      // It is relative to `vetur.config.js`.
+      root: './front',
+      // **optional** default: `'package.json'`
+      // Where is `package.json` in the project?
+      // We use it to determine the version of vue.
+      // It is relative to root property.
+      package: './package.json',
+      // **optional**
+      // Where is TypeScript config file in the project?
+      // It is relative to root property.
+      tsconfig: './tsconfig.json',
+      // **optional** default: `'./.vscode/vetur/snippets'`
+      // Where is vetur custom snippets folders?
+      snippetFolder: './.vscode/vetur/snippets',
+      // **optional** default: `[]`
+      // Register globally Vue component glob.
+      // If you set it, you can get completion by that components.
+      // It is relative to root property.
+      // Notice: It won't actually do it. You need to use `require.context` or `Vue.component`
+      globalComponents: [
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

- トップページを作成し、気分選択ボタンをそれに応じた絵文字が表示されるようにしました

<img width="1330" alt="image" src="https://github.com/user-attachments/assets/a902914a-6c27-486c-b4ec-c7575668568a" />


## 変更点

- `front/pages/index.vue`を作成
- `front/components/MoodSelector.vue`を作成しindex.vueでインポート

## 影響範囲
- なし

## テスト
なし

## やってないこと
- 決定ボタン選択後の処理
- スタイルの切り分け（別途scss作成）
- `index.vue`で`MooddSelector.vue`のエクスポートでエラー出ているが、<script setup>を使用している場合は問題ないはず。別途調査します
```
Module '"/Users/suzukimarika/workspace/meshiuchi/meshiuchi/front/components/MoodSelector.vue"' has no default export.
```

## 関連Issue
- #3 